### PR TITLE
Added detection for "call" statements as dependencies.

### DIFF
--- a/src/Niche.NAntGraph.Tests/NAntTargetTests.cs
+++ b/src/Niche.NAntGraph.Tests/NAntTargetTests.cs
@@ -124,6 +124,21 @@ namespace Niche.NAntGraph.Tests
         }
 
         [Test]
+        public void FromXml_withSCalls_returnsNAntTargetWithDepends()
+        {
+            const string TargetName = "compile.target";
+            const string Depends = "compile.dependency";
+            var element
+                = new XElement(
+                    "target",
+                    new XAttribute("name", TargetName),
+                    new XElement("call", new XAttribute("target", Depends)));
+            var target = NAntTarget.FromXml(element);
+            Assert.That(target.Depends, Has.Member(Depends));
+        }
+
+        
+        [Test]
         [ExpectedException(typeof(ArgumentNullException))]
         public void Visit_missingVisitor_throwsException()
         {

--- a/src/Niche.NAntGraph/NAntTarget.cs
+++ b/src/Niche.NAntGraph/NAntTarget.cs
@@ -66,6 +66,11 @@ namespace Niche.NAntGraph
             var depends = (string)element.Attribute("depends") 
                 ?? string.Empty;
 
+            var callers = element.DescendantNodes().Where(e => (e is XElement) &&  ((XElement) e).Name == "call");
+            var callerList = callers.Select(caller => (string) ((XElement) caller).Attribute("target") ?? "");
+
+            depends += string.Join(",", callerList);
+
             return new NAntTarget(name, description, depends);
         }
 


### PR DESCRIPTION
The existing application didn't recognise when a target calls out to another target - so only 1/3 of our dependency chain was being recognised.  This adds that funtionality.
